### PR TITLE
Make bump version script output linter-compatible dates

### DIFF
--- a/bump-version.rb
+++ b/bump-version.rb
@@ -55,7 +55,7 @@ end
 
 github = JSON.parse(URI.parse('https://api.github.com/repos/magicstone-dev/ecko/branches/main').read)
 last_commit = github["commit"]["sha"]
-version = Date.parse(github["commit"]["commit"]["author"]["date"]).to_s
+version = Date.parse(github["commit"]["commit"]["author"]["date"]).to_s.gsub '-', '.'
 
 url = "https://github.com/magicstone-dev/ecko/archive/#{last_commit}.tar.gz"
 


### PR DESCRIPTION
## Problem

- #11 

## Solution

- The issue with the latest version was fixed by #10
- Future versions will be generated by bump-version.rb which was fixed with #12 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
