### PR TITLE
bump version to 2021.12.27~ynh1

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/b0e95b3a9b14b0b9bb7aed46241db259037b1f3b.tar.gz
-SOURCE_SUM=eb9d77ee0cbfff2f14712cd18ac6697f63a37ac7f994ebee55b591df13cdf18b
+SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/e581c1a3a0bbf985acc56670a5c79bf63289eac9.tar.gz
+SOURCE_SUM=5dbf6101e7a75ba6188133d9a8230daa87e160d8b583c1f5e58f693c8f2765e2
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=b0e95b3a9b14b0b9bb7aed46241db259037b1f3b.tar.gz
+SOURCE_FILENAME=e581c1a3a0bbf985acc56670a5c79bf63289eac9.tar.gz
 SOURCE_EXTRACT=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Dynamic fork of Mastodon's federated social network, est. Aug 2021.",
         "fr": "Fork dynamique du réseau social fédéré de Mastodon, créé en août 2021."
     },
-    "version": "2021.12.09~ynh1",
+    "version": "2021.12.27~ynh1",
     "url": "https://github.com/magicstone-dev/ecko",
     "upstream": {
         "license": "free",


### PR DESCRIPTION
## Problem

- Package was behind Ecko main so didn't have Stripe donations, additional themes, domain blocklist import

## Solution

- Run bump_version.rb

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
