### PR TITLE
applies updates to main from upstream for v3.4.6

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/a15bad2418a6366357a21169029c1e197c970c31.tar.gz
-SOURCE_SUM=0faadbdba48cffb40c29dd8ecb73d9f6dff52bcaac57d005bfa8d0f39e1adb8a
+SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/a324b92863df6374ff47c354baf61d49dbbe5ab1.tar.gz
+SOURCE_SUM=6c1dd321840e7ef4e0d05d780cf740914946f852dc885cf9422cf02ed3159481
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=a15bad2418a6366357a21169029c1e197c970c31.tar.gz
+SOURCE_FILENAME=a324b92863df6374ff47c354baf61d49dbbe5ab1.tar.gz
 SOURCE_EXTRACT=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Dynamic fork of Mastodon's federated social network, est. Aug 2021.",
         "fr": "Fork dynamique du réseau social fédéré de Mastodon, créé en août 2021."
     },
-    "version": "2022.01.31~ynh1",
+    "version": "2022.02.03~ynh1",
     "url": "https://github.com/magicstone-dev/ecko",
     "upstream": {
         "license": "free",


### PR DESCRIPTION
## Problem

- Security updates were released today for Mastodon

## Solution

- Apply updates and bump version to latest ecko main

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
