### PR TITLE
bump version with Mastodon v4.0.2 security fix

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,7 @@
-SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/b3d7f7d1604b05e8c2dfd6249b6a39b1ca8e80b4.tar.gz
-SOURCE_SUM=c138ffabcbd3f981a62dc9ca6768b2f3f9cf9b8b3057d7847191108c35bdf6e4
+SOURCE_URL=https://github.com/magicstone-dev/ecko/archive/26085c8a6c04352175a9e26f816f3fba2b29b2b4.tar.gz
+SOURCE_SUM=f04949611dac4656cdc7eba279f0c8c0ebdf6b1a31648bae3226f012dc130d7c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=b3d7f7d1604b05e8c2dfd6249b6a39b1ca8e80b4.tar.gz
+SOURCE_FILENAME=26085c8a6c04352175a9e26f816f3fba2b29b2b4.tar.gz
 SOURCE_EXTRACT=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Dynamic fork of Mastodon's federated social network, est. Aug 2021.",
         "fr": "Fork dynamique du réseau social fédéré de Mastodon, créé en août 2021."
     },
-    "version": "2022.11.14~ynh1",
+    "version": "2022.11.15~ynh1",
     "url": "https://github.com/magicstone-dev/ecko",
     "upstream": {
         "license": "free",


### PR DESCRIPTION
## Problem

- Security fixes were pending

## Solution

- A security fix was released in Mastodon v4.0.2 which this includes

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
